### PR TITLE
Feat: Google OAuth2 로그인 구현 및 JWT 인증 작업

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+//    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
@@ -27,6 +27,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/team/react/school_chat/auth/controller/TestController.kt
+++ b/src/main/kotlin/team/react/school_chat/auth/controller/TestController.kt
@@ -1,0 +1,17 @@
+package team.react.school_chat.auth.controller
+
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+@RequestMapping("/api/user")
+class TestController() {
+    @GetMapping("/email")
+    fun getUserEmail(authentication: Authentication): Map<String, String> {
+        val response = mapOf("email" to authentication.name)
+        return response
+    }
+}

--- a/src/main/kotlin/team/react/school_chat/auth/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/team/react/school_chat/auth/service/CustomOAuth2UserService.kt
@@ -1,0 +1,51 @@
+package team.react.school_chat.auth.service
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+import team.react.school_chat.auth.utils.JwtProvider
+import team.react.school_chat.auth.utils.OAuthAttributes
+import java.util.*
+
+@Service
+class CustomOAuth2UserService(
+    private val jwtProvider: JwtProvider
+): OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
+        val delegate = DefaultOAuth2UserService()
+        val oAuth2User = delegate.loadUser(userRequest)
+
+        val registrationId = userRequest
+            .clientRegistration
+            .registrationId
+
+        val userNameAttributeName = userRequest
+            .clientRegistration
+            .providerDetails
+            .userInfoEndpoint
+            .userNameAttributeName
+
+        val attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.attributes)
+            .apply {
+                attributes.toMutableMap().apply {
+                    put("token", jwtProvider.generateToken(email))
+                }
+            }
+
+        val token = jwtProvider.generateToken(attributes.email)
+
+        val updatedAttributes = attributes.attributes.toMutableMap().apply {
+            put("token", jwtProvider.generateToken(attributes.email))
+        }
+
+        return DefaultOAuth2User(
+            Collections.singleton(SimpleGrantedAuthority("ROLE_USER")),
+            attributes.attributes,
+            attributes.nameAttributeKey
+        )
+    }
+}

--- a/src/main/kotlin/team/react/school_chat/auth/utils/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/team/react/school_chat/auth/utils/JwtAuthenticationFilter.kt
@@ -1,0 +1,58 @@
+package team.react.school_chat.auth.utils
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtProvider: JwtProvider
+) : OncePerRequestFilter() {
+    private val protectedPaths = listOf("/api/user/email")
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        return !protectedPaths.any { request.requestURI.startsWith(it) }
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        println("JWT Filter excute: ${request.requestURI}")
+
+        val token = resolveToken(request)
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            val email = jwtProvider.getEmailFromToken(token)
+            val authentication = UsernamePasswordAuthenticationToken(email, null, listOf(SimpleGrantedAuthority("ROLE_USER")))
+            SecurityContextHolder.getContext().authentication = authentication
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        response.sendError(HttpStatus.UNAUTHORIZED.value(), "Invalid or Expired Token")
+
+
+
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String? {
+        val bearerToken = request.getHeader("Authorization")
+        return if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            bearerToken.substring(7)
+        } else null
+    }
+
+    private fun handleException(response: HttpServletResponse, message: String, status: HttpStatus) {
+        response.status = status.value()
+        response.contentType = "application/json"
+        response.writer.write("{\"error\": \"$message\"}")
+    }
+}

--- a/src/main/kotlin/team/react/school_chat/auth/utils/JwtProvider.kt
+++ b/src/main/kotlin/team/react/school_chat/auth/utils/JwtProvider.kt
@@ -1,0 +1,41 @@
+package team.react.school_chat.auth.utils
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import io.jsonwebtoken.security.Keys
+import java.util.Date
+
+
+@Component
+class JwtProvider(
+    @Value("\${jwt.secret}")
+    private val secretKey: String,
+) {
+    private val key = Keys.hmacShaKeyFor(secretKey.toByteArray())
+
+    fun generateToken(email: String): String {
+        return Jwts.builder()
+            .setSubject(email)
+            .setIssuedAt(Date())
+            .setExpiration(Date(System.currentTimeMillis() + 1000 * 60 * 60)) // 1시간 유효
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact()
+    }
+
+    fun validateToken(token: String): Boolean {
+        return try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    fun getEmailFromToken(token: String): String {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body.subject
+    }
+
+
+}

--- a/src/main/kotlin/team/react/school_chat/auth/utils/OAuth2LoginSuccessHandler.kt
+++ b/src/main/kotlin/team/react/school_chat/auth/utils/OAuth2LoginSuccessHandler.kt
@@ -1,0 +1,28 @@
+package team.react.school_chat.auth.utils
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+
+@Component
+class OAuth2LoginSuccessHandler(
+    private val jwtProvider: JwtProvider
+) : AuthenticationSuccessHandler {
+
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+        val oAuth2User = authentication.principal as DefaultOAuth2User
+        val email = oAuth2User.attributes["email"] as String // OAuth2에서 제공하는 email
+
+        val token = jwtProvider.generateToken(email)
+
+        response.contentType = "application/json"
+        response.writer.write("{\"token\": \"$token\"}") // JSON 응답
+    }
+}

--- a/src/main/kotlin/team/react/school_chat/auth/utils/OAuthAttributes.kt
+++ b/src/main/kotlin/team/react/school_chat/auth/utils/OAuthAttributes.kt
@@ -1,0 +1,31 @@
+package team.react.school_chat.auth.utils
+
+
+data class OAuthAttributes(
+    val attributes: MutableMap<String, Any>,
+    val nameAttributeKey: String,
+    val name: String,
+    val email: String,
+    val picture: String,
+) {
+    companion object {
+        /**
+         * @param registrationId OAuth 서비스명(ex: google, kakao, naver...) 후의 다른 OAuth의 확장을 고려하여 사용은 하지 않지만 인자를 받음
+         * @param userAttributeName
+         * @param attributes OAuth 성공시 제공 받는 데이터들
+         */
+        fun of(registrationId: String, userAttributeName: String, attributes: MutableMap<String, Any>): OAuthAttributes {
+            return ofGoogle(userAttributeName, attributes)
+        }
+
+        private fun ofGoogle(userNameAttributeName: String, attributes: MutableMap<String, Any>): OAuthAttributes {
+            return OAuthAttributes(
+                name = attributes["name"] as String,
+                email = attributes["email"] as String,
+                picture = attributes["picture"] as String,
+                attributes = attributes,
+                nameAttributeKey = userNameAttributeName,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/react/school_chat/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/team/react/school_chat/global/config/SecurityConfiguration.kt
@@ -1,0 +1,36 @@
+package team.react.school_chat.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.security.web.context.SecurityContextPersistenceFilter
+import team.react.school_chat.auth.utils.JwtAuthenticationFilter
+import team.react.school_chat.auth.utils.OAuth2LoginSuccessHandler
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfiguration(
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val oAuth2LoginSuccessHandler: OAuth2LoginSuccessHandler
+) {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf {
+                it.disable()
+            }
+            .authorizeHttpRequests { it
+                .requestMatchers("/api/user/email").authenticated()
+                .anyRequest().permitAll()
+            }
+            .oauth2Login {
+                it.successHandler(oAuth2LoginSuccessHandler)
+            }
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+
+        return http.build()
+    }
+}


### PR DESCRIPTION
# Google OAuth2 로그인 테스트
/login url 접속을 통해 기본 security 로그인에서 Google OAuth2 로그인 가능

# Google OAuth2 성공 이후 JWT Token 발급
~~~json
{
  "token": "{token value}"
}
~~~
위와 같은 형식의 요청이 response됨

# JWT Token 인증 테스트
## Request
URL: http://localhost:8080/api/user/email
METHOD: GET
Header: Authorization Bearer 형식으로 Token 삽입
## Response
```json
  "email": "{발급받은 Google OAuth email}"
```
---
위와 같은 형태로 이메일을 반환