### PR TITLE
Feat: 커스텀 오류 정의

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     kotlin("plugin.spring") version "1.9.25"
     id("org.springframework.boot") version "3.4.3"
     id("io.spring.dependency-management") version "1.1.7"
+    kotlin("plugin.jpa") version "1.9.25"
 }
 
 group = "team.react"
@@ -19,7 +20,8 @@ repositories {
 }
 
 dependencies {
-//    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
@@ -30,6 +32,7 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+    runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
@@ -40,6 +43,12 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict")
     }
+}
+
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/team/react/school_chat/auth/controller/AuthController.kt
+++ b/src/main/kotlin/team/react/school_chat/auth/controller/AuthController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/user")
-class TestController() {
+class AuthController() {
     @GetMapping("/email")
     fun getUserEmail(authentication: Authentication): Map<String, String> {
         val response = mapOf("email" to authentication.name)

--- a/src/main/kotlin/team/react/school_chat/global/exception/CustomException.kt
+++ b/src/main/kotlin/team/react/school_chat/global/exception/CustomException.kt
@@ -1,0 +1,3 @@
+package team.react.school_chat.global.exception
+
+class CustomException(val errorCode: ErrorCode, val details: String = ""): RuntimeException() {}

--- a/src/main/kotlin/team/react/school_chat/global/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/team/react/school_chat/global/exception/CustomExceptionHandler.kt
@@ -1,0 +1,14 @@
+package team.react.school_chat.global.exception
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class CustomExceptionHandler {
+    @ExceptionHandler(CustomException::class)
+    fun handleException(exception: CustomException, request: HttpServletRequest): ResponseEntity<ErrorResponseBody> {
+        return ErrorResponseEntity(exception).toResponseEntity()
+    }
+}

--- a/src/main/kotlin/team/react/school_chat/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/team/react/school_chat/global/exception/ErrorCode.kt
@@ -4,6 +4,9 @@ import org.springframework.http.HttpStatus
 
 enum class ErrorCode(val httpStatus: HttpStatus, val message: String) {
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 대한 결과를 찾을 수 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "요청에 대한 권한이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "요청이 거부되었습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 리소스 입니다.")
+    ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 리소스 입니다."),
+
 }

--- a/src/main/kotlin/team/react/school_chat/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/team/react/school_chat/global/exception/ErrorCode.kt
@@ -1,0 +1,9 @@
+package team.react.school_chat.global.exception
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(val httpStatus: HttpStatus, val message: String) {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 대한 결과를 찾을 수 없습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 리소스 입니다.")
+}

--- a/src/main/kotlin/team/react/school_chat/global/exception/ErrorResponseBody.kt
+++ b/src/main/kotlin/team/react/school_chat/global/exception/ErrorResponseBody.kt
@@ -1,0 +1,7 @@
+package team.react.school_chat.global.exception
+
+data class ErrorResponseBody(
+    val status: Int,
+    val message: String,
+    val details: String
+)

--- a/src/main/kotlin/team/react/school_chat/global/exception/ErrorResponseEntity.kt
+++ b/src/main/kotlin/team/react/school_chat/global/exception/ErrorResponseEntity.kt
@@ -1,0 +1,17 @@
+package team.react.school_chat.global.exception
+
+import org.springframework.http.ResponseEntity
+
+data class ErrorResponseEntity(val exception: CustomException) {
+    private val errorCode = exception.errorCode
+
+    fun toResponseEntity(): ResponseEntity<ErrorResponseBody> =
+        ResponseEntity(
+            ErrorResponseBody(
+                this.errorCode.httpStatus.value(),
+                this.errorCode.message,
+                this.exception.details
+            ),
+            this.errorCode.httpStatus
+        )
+}


### PR DESCRIPTION
# Custom Exception
**RestControllerAdvice**를 통하여 발생되는 Exception을 **ExceptionHandler**를 사용해 **CustomException**에 대해여 반환되는 **RespnseEntity**를 재정의
# Custom Exception 사용
~~~kotlin
throw CustomException({ErrorCode}, {detail})
~~~
위와 같은 방식으로 **CustomException**을 사용한다.
## ErrorCode
**ErrorCode**는 다음과 같은 형태의 Enum으로 정의 되어 있음
~~~kotlin
enum class ErrorCode(val httpStatus: HttpStatus, val message: String) {
    NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 대한 결과를 찾을 수 없습니다."),
    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
    ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 리소스 입니다.")
}
~~~
각 HTTP Status에 맞는 message가 포함되어 있으며 만약 위에 정의된 **ErrorCode**들중 원하는 HTTP Status가 없다면 추가하여 사용한다.
## Detail
문자열 타입으로 작성하며 해당 오류를 클라이언트에게 자세한 메시지를 통하여 전할때 사용한다.
기본값은 빈 문자열("") 이므로 필수가 아니다.
# 실제 사용 예시와 결과
~~~kotlin
# 이메일을 통하여 사용자를 찾는데 이메일이 없는 경우
throw CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 계정 이메일 입니다.")
~~~
## PostMan에서 실제 결과
<img width="685" alt="image" src="https://github.com/user-attachments/assets/cf9ddf75-0f40-4282-bd1d-12c3b842e183" />